### PR TITLE
Change CANCTRL register value names to avoid generic naming collisions

### DIFF
--- a/example/test.cpp
+++ b/example/test.cpp
@@ -92,7 +92,7 @@ bool can_init(uint8_t cs_pin, uint8_t int_pin, uint8_t speed, uint8_t clock)
     }
 
     // Set NORMAL mode
-    if(CAN.setMode(MODE_NORMAL) == MCP2515_OK) {
+    if(CAN.setMode(MCP_MODE_NORMAL) == MCP2515_OK) {
         Log.info("CAN mode set");
     }
     else {
@@ -119,18 +119,18 @@ bool can_sleep(uint32_t timeout_ms)
 
     while(1) {
         // Set sleep mode
-        CAN.setMode(MODE_SLEEP);
+        CAN.setMode(MCP_MODE_SLEEP);
 
         // check CAN Operation Mode
         op_mode = CAN.getCANStatus() & 0xE0;
 
-        if((op_mode == MODE_SLEEP) || (try_time >= timeout_ms)) {
+        if((op_mode == MCP_MODE_SLEEP) || (try_time >= timeout_ms)) {
             break;
         }
         try_time += 10;
         delay(10);
     }
-    return (op_mode == MODE_SLEEP);
+    return (op_mode == MCP_MODE_SLEEP);
 }
 
 void setup()

--- a/src/mcp_can.cpp
+++ b/src/mcp_can.cpp
@@ -298,8 +298,8 @@ void MCP_CAN::setSleepWakeup(const byte enable) {
 ** Descriptions:            Put mcp2515 in sleep mode to save power
 *********************************************************************************************************/
 byte MCP_CAN::sleep() {
-    if (getMode() != MODE_SLEEP) {
-        return mcp2515_setCANCTRL_Mode(MODE_SLEEP);
+    if (getMode() != MCP_MODE_SLEEP) {
+        return mcp2515_setCANCTRL_Mode(MCP_MODE_SLEEP);
     } else {
         return CAN_OK;
     }
@@ -324,7 +324,7 @@ byte MCP_CAN::wake() {
 *********************************************************************************************************/
 byte MCP_CAN::setMode(const byte opMode) {
     if (opMode !=
-            MODE_SLEEP) { // if going to sleep, the value stored in opMode is not changed so that we can return to it later
+            MCP_MODE_SLEEP) { // if going to sleep, the value stored in opMode is not changed so that we can return to it later
         mcpMode = opMode;
     }
     return mcp2515_setCANCTRL_Mode(opMode);
@@ -345,7 +345,7 @@ byte MCP_CAN::getCANStatus()
 ** Descriptions:            Returns current control mode
 *********************************************************************************************************/
 byte MCP_CAN::getMode() {
-    return mcp2515_readRegister(MCP_CANSTAT) & MODE_MASK;
+    return mcp2515_readRegister(MCP_CANSTAT) & MCP_MODE_MASK;
 }
 
 /*********************************************************************************************************
@@ -356,7 +356,7 @@ byte MCP_CAN::mcp2515_setCANCTRL_Mode(const byte newmode) {
     // If the chip is asleep and we want to change mode then a manual wake needs to be done
     // This is done by setting the wake up interrupt flag
     // This undocumented trick was found at https://github.com/mkleemann/can/blob/master/can_sleep_mcp2515.c
-    if ((getMode()) == MODE_SLEEP && newmode != MODE_SLEEP) {
+    if ((getMode()) == MCP_MODE_SLEEP && newmode != MCP_MODE_SLEEP) {
         // Make sure wake interrupt is enabled
         byte wakeIntEnabled = (mcp2515_readRegister(MCP_CANINTE) & MCP_WAKIF);
         if (!wakeIntEnabled) {
@@ -372,7 +372,7 @@ byte MCP_CAN::mcp2515_setCANCTRL_Mode(const byte newmode) {
         // as it's put to sleep, but it will stay in SLEEP mode instead of automatically switching to LISTENONLY mode.
         // In this situation the mode needs to be manually set to LISTENONLY.
 
-        if (mcp2515_requestNewMode(MODE_LISTENONLY) != MCP2515_OK) {
+        if (mcp2515_requestNewMode(MCP_MODE_LISTENONLY) != MCP2515_OK) {
             return MCP2515_FAIL;
         }
 
@@ -399,10 +399,10 @@ byte MCP_CAN::mcp2515_requestNewMode(const byte newmode) {
     while (1) {
         // Request new mode
         // This is inside the loop as sometimes requesting the new mode once doesn't work (usually when attempting to sleep)
-        mcp2515_modifyRegister(MCP_CANCTRL, MODE_MASK, newmode);
+        mcp2515_modifyRegister(MCP_CANCTRL, MCP_MODE_MASK, newmode);
 
         byte statReg = mcp2515_readRegister(MCP_CANSTAT);
-        if ((statReg & MODE_MASK) == newmode) { // We're now in the new mode
+        if ((statReg & MCP_MODE_MASK) == newmode) { // We're now in the new mode
             return MCP2515_OK;
         } else if ((millis() - startTime) > 200) { // Wait no more than 200ms for the operation to complete
             return MCP2515_FAIL;
@@ -723,7 +723,7 @@ byte MCP_CAN::mcp2515_init(const byte mode, const byte canSpeed, const byte cloc
 
     mcp2515_reset();
 
-    res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
+    res = mcp2515_setCANCTRL_Mode(MCP_MODE_CONFIG);
     if (res > 0) {
         LOGI("Entering Configuration Mode Failure...");
         return res;
@@ -765,7 +765,7 @@ byte MCP_CAN::mcp2515_init(const byte mode, const byte canSpeed, const byte cloc
         }
 
         // enter normal mode
-        res = setMode(MODE_NORMAL);
+        res = setMode(MCP_MODE_NORMAL);
         if (res) {
             LOGI("Returning to Previous Mode Failure...");
             return res;
@@ -999,7 +999,7 @@ void MCP_CAN::enableTxInterrupt(bool enable) {
 byte MCP_CAN::init_Mask(byte num, byte ext, unsigned long ulData) {
     byte res = MCP2515_OK;
     LOGI("Starting to Set Mask!");
-    res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
+    res = mcp2515_setCANCTRL_Mode(MCP_MODE_CONFIG);
     if (res > 0) {
         LOGI("Entering Configuration Mode Failure...");
         return res;
@@ -1031,7 +1031,7 @@ byte MCP_CAN::init_Filt(byte num, byte ext, unsigned long ulData) {
     byte res = MCP2515_OK;
 
     LOGI("Starting to Set Filter!");
-    res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
+    res = mcp2515_setCANCTRL_Mode(MCP_MODE_CONFIG);
     if (res > 0) {
         LOGI("Enter Configuration Mode Failure...");
         return res;
@@ -1380,7 +1380,7 @@ bool MCP_CAN::mcpPinMode(const byte pin, const byte mode) {
             return true;
             break;
         case MCP_TX0RTS:
-            res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
+            res = mcp2515_setCANCTRL_Mode(MCP_MODE_CONFIG);
             if (res > 0) {
                 LOGI("Entering Configuration Mode Failure...");
                 delay(10);
@@ -1406,7 +1406,7 @@ bool MCP_CAN::mcpPinMode(const byte pin, const byte mode) {
             return ret;
             break;
         case MCP_TX1RTS:
-            res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
+            res = mcp2515_setCANCTRL_Mode(MCP_MODE_CONFIG);
             if (res > 0) {
                 LOGI("Entering Configuration Mode Failure...");
                 delay(10);
@@ -1432,7 +1432,7 @@ bool MCP_CAN::mcpPinMode(const byte pin, const byte mode) {
             return ret;
             break;
         case MCP_TX2RTS:
-            res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
+            res = mcp2515_setCANCTRL_Mode(MCP_MODE_CONFIG);
             if (res > 0) {
                 LOGI("Entering Configuration Mode Failure...");
                 delay(10);

--- a/src/mcp_can.h
+++ b/src/mcp_can.h
@@ -49,7 +49,7 @@
 
 #include "mcp_can_dfs.h"
 
-#define MAX_CHAR_IN_MESSAGE 8
+#define MAX_CHAR_IN_MESSAGE (CAN_MAX_CHAR_IN_MESSAGE)
 
 class MCP_CAN {
   private:

--- a/src/mcp_can_dfs.h
+++ b/src/mcp_can_dfs.h
@@ -198,21 +198,21 @@
 
 // CANCTRL Register Values
 
-#define MODE_NORMAL     0x00
-#define MODE_SLEEP      0x20
-#define MODE_LOOPBACK   0x40
-#define MODE_LISTENONLY 0x60
-#define MODE_CONFIG     0x80
-#define MODE_POWERUP    0xE0
-#define MODE_MASK       0xE0
-#define ABORT_TX        0x10
-#define MODE_ONESHOT    0x08
-#define CLKOUT_ENABLE   0x04
-#define CLKOUT_DISABLE  0x00
-#define CLKOUT_PS1      0x00
-#define CLKOUT_PS2      0x01
-#define CLKOUT_PS4      0x02
-#define CLKOUT_PS8      0x03
+#define MCP_MODE_NORMAL     0x00
+#define MCP_MODE_SLEEP      0x20
+#define MCP_MODE_LOOPBACK   0x40
+#define MCP_MODE_LISTENONLY 0x60
+#define MCP_MODE_CONFIG     0x80
+#define MCP_MODE_POWERUP    0xE0
+#define MCP_MODE_MASK       0xE0
+#define MCP_ABORT_TX        0x10
+#define MCP_MODE_ONESHOT    0x08
+#define MCP_CLKOUT_ENABLE   0x04
+#define MCP_CLKOUT_DISABLE  0x00
+#define MCP_CLKOUT_PS1      0x00
+#define MCP_CLKOUT_PS2      0x01
+#define MCP_CLKOUT_PS4      0x02
+#define MCP_CLKOUT_PS8      0x03
 
 
 // CNF1 Register Values


### PR DESCRIPTION
### Problem
The names for register CANCTRL values are very generic and may collide with other library defines using the same name.

### Solution
Rename (prepend with `"MCP_"`) the existing register values for CANCTRL so that they don't collide.