### PR TITLE
Remove chip select define linkage and adjust for fast IO automatically

### DIFF
--- a/example/test.cpp
+++ b/example/test.cpp
@@ -19,10 +19,6 @@ SYSTEM_MODE(SEMI_AUTOMATIC);
 
 #if PLATFORM_ID == PLATFORM_TRACKER
 
-#ifndef MCP2515_NORMAL_WRITES
-#error "MCP2515_NORMAL_WRITES must be defined for the tracker platform!"
-#endif // MCP2515_NORMAL_WRITES
-
 #define CAN_SPI_INTERFACE         (SPI1)
 #define APP_CONFIG_UNUSED         (-1)
 #define CAN_CS_PIN                (CAN_CS)

--- a/src/mcp_can.h
+++ b/src/mcp_can.h
@@ -51,6 +51,8 @@
 
 #define MAX_CHAR_IN_MESSAGE (CAN_MAX_CHAR_IN_MESSAGE)
 
+using spiCsSetter = void(uint16_t, uint8_t);
+
 class MCP_CAN {
   private:
 
@@ -59,6 +61,7 @@ class MCP_CAN {
     unsigned long  can_id;                  // can id
     byte   rtr;                             // rtr
     byte   SPICS;
+    spiCsSetter* csSetter;
     byte   nReservedTx = 0;                     // Count of tx buffers for reserved send
     byte   mcpMode;                         // Current controller mode
 
@@ -71,6 +74,8 @@ class MCP_CAN {
   private:
 
     void mcp2515_reset(void);                                   // reset mcp2515
+
+    bool mcp2515_isFastSupported(pin_t _pin);                   // get fast IO capabilities
 
     byte mcp2515_readRegister(const byte address);              // read mcp2515's register
 

--- a/src/mcp_can_dfs.h
+++ b/src/mcp_can_dfs.h
@@ -452,15 +452,6 @@
 #define MCP_RXBUF_0 (MCP_RXB0SIDH)
 #define MCP_RXBUF_1 (MCP_RXB1SIDH)
 
-// Default to fast digital writes unless specified
-#ifdef MCP2515_NORMAL_WRITES
-#define MCP2515_SELECT()   digitalWrite(SPICS, LOW)
-#define MCP2515_UNSELECT() digitalWrite(SPICS, HIGH)
-#else
-#define MCP2515_SELECT()   digitalWriteFast(SPICS, LOW)
-#define MCP2515_UNSELECT() digitalWriteFast(SPICS, HIGH)
-#endif // MCP2515_NORMAL_WRITES
-
 #define MCP2515_OK         (0)
 #define MCP2515_FAIL       (1)
 #define MCP_ALLTXBUSY      (2)


### PR DESCRIPTION
### Problem
The following preprocessor check for the type of `digitalWrite()` method to use is not friendly for cloud compiles and is easily missed when it is not selected correctly.

```cpp
// Default to fast digital writes unless specified
#ifdef MCP2515_NORMAL_WRITES
#define MCP2515_SELECT()   digitalWrite(SPICS, LOW)
#define MCP2515_UNSELECT() digitalWrite(SPICS, HIGH)
#else
#define MCP2515_SELECT()   digitalWriteFast(SPICS, LOW)
#define MCP2515_UNSELECT() digitalWriteFast(SPICS, HIGH)
#endif // MCP2515_NORMAL_WRITES
```

### Solution
Automatically assess if the chip select pin is fast write capable upon class instantiation and adjust for the correct API.