### PR TITLE
Allow starting device in MCP_MODE_LISTENONLY

### DIFF
--- a/src/mcp_can.cpp
+++ b/src/mcp_can.cpp
@@ -739,7 +739,7 @@ void MCP_CAN::mcp2515_initCANBuffers(void) {
 ** Function name:           mcp2515_init
 ** Descriptions:            init the device
 *********************************************************************************************************/
-byte MCP_CAN::mcp2515_init(const byte mode, const byte canSpeed, const byte clock) {
+byte MCP_CAN::mcp2515_init(const byte mode, const byte canSpeed, const byte clock, const byte opMode) {
 
     byte res;
 
@@ -786,8 +786,8 @@ byte MCP_CAN::mcp2515_init(const byte mode, const byte canSpeed, const byte cloc
                                MCP_RXB_RX_STDEXT);
         }
 
-        // enter normal mode
-        res = setMode(MCP_MODE_NORMAL);
+        // enter normal mode (default) or other user-specified mode (such as MCP_MODE_LISTENONLY)
+        res = setMode(opMode);
         if (res) {
             LOGI("Returning to Previous Mode Failure...");
             return res;
@@ -999,9 +999,9 @@ MCP_CAN::MCP_CAN(byte _CS, SPIClass &spi, int speed) :
 ** Function name:           begin
 ** Descriptions:            init can and set speed
 *********************************************************************************************************/
-byte MCP_CAN::begin(byte mode, byte speedset, const byte clockset) {
+byte MCP_CAN::begin(byte mode, byte speedset, const byte clockset, const byte opMode) {
     spi.begin(PIN_INVALID);
-    byte res = mcp2515_init(mode, speedset, clockset);
+    byte res = mcp2515_init(mode, speedset, clockset, opMode);
 
     return ((res == MCP2515_OK) ? CAN_OK : CAN_FAILINIT);
 }

--- a/src/mcp_can.h
+++ b/src/mcp_can.h
@@ -99,7 +99,7 @@ class MCP_CAN {
     byte mcp2515_setCANCTRL_Mode(const byte newmode);           // set mode
     byte mcp2515_requestNewMode(const byte newmode);                  // Set mode
     byte mcp2515_configRate(const byte canSpeed, const byte clock);  // set baudrate
-    byte mcp2515_init(const byte mode, const byte canSpeed, const byte clock);   // mcp2515init
+    byte mcp2515_init(const byte mode, const byte canSpeed, const byte clock, const byte opMode = MCP_MODE_NORMAL);   // mcp2515init
 
     void mcp2515_write_id(const byte mcp_addr,                  // write can id
                           const byte ext,
@@ -133,7 +133,7 @@ class MCP_CAN {
         return MCP_N_TXBUFFERS - 1;    // read index of last tx buffer
     }
 
-    byte begin(byte mode, byte speedset, const byte clockset = MCP_16MHz); // init can
+    byte begin(byte mode, byte speedset, const byte clockset = MCP_16MHz, const byte opMode = MCP_MODE_NORMAL); // init can
     byte minimalInit(); // minimal init
     byte init_Mask(byte num, byte ext, unsigned long ulData);       // init Masks
     byte init_Filt(byte num, byte ext, unsigned long ulData);       // init filters


### PR DESCRIPTION
### Problem
The current behavior of `MCP_CAN::mcp2515_init` is to always call `setMode(MCP_MODE_NORMAL)`, which is a very dangerous thing if you do it on any vehicle - the chip may start sending NACK or error frames which can disturb the bus and affect operations in other systems.

### Solution
Add parameter to `MCP_CAN::mcp2515_init` and `MCP_CAN::begin` to allow starting in `MCP_MODE_LISTENONLY` mode.