### PR TITLE
Change HAL_Pin_Map to Hal_Pin_Map to fix compile failure

### DIFF
--- a/src/mcp_can.cpp
+++ b/src/mcp_can.cpp
@@ -191,7 +191,7 @@ bool MCP_CAN::mcp2515_isFastSupported(pin_t _pin)
     {
         return false;
     }
-    Hal_Pin_Type type = HAL_Pin_Map()[_pin].type;
+    Hal_Pin_Type type = Hal_Pin_Map()[_pin].type;
     return (type == HAL_PIN_TYPE_MCU);
 #else
     // Everthing IO is based from the MCU


### PR DESCRIPTION
Compile Failure against 5.0.0 fixed by changing case of HAL_Pin_Map to Hal_Pin_Map