### PR TITLE
Fix HAL calls to check fast IO under device OS 5.x

### DIFF
--- a/src/mcp_can.cpp
+++ b/src/mcp_can.cpp
@@ -191,7 +191,13 @@ bool MCP_CAN::mcp2515_isFastSupported(pin_t _pin)
     {
         return false;
     }
-    Hal_Pin_Type type = HAL_Pin_Map()[_pin].type;
+    auto type =
+#if (SYSTEM_VERSION < SYSTEM_VERSION_ALPHA(5, 0, 0, 1))
+        HAL_Pin_Map()[_pin].type;
+#else // SYSTEM_VERSION
+        hal_pin_map()[_pin].type;
+#endif // SYSTEM_VERSION
+
     return (type == HAL_PIN_TYPE_MCU);
 #else
     // Everthing IO is based from the MCU


### PR DESCRIPTION
### Problem
This CAN library fails to compile under device OS 5.x because some of the HAL API names were changed.

### Solution
Check the version of device OS being compiled against and use the appropriate HAL API.
