### PR TITLE
Add MCP25625 to handle sleep and wake with integrated transceiver

### DIFF
--- a/src/mcp_25625.cpp
+++ b/src/mcp_25625.cpp
@@ -1,0 +1,29 @@
+#include "mcp_25625.h"
+
+MCP_CAN_25625::MCP_CAN_25625(pin_t cs, pin_t standby, SPIClass &spi, int speed)
+	: MCP_CAN(cs, spi, speed),
+	  standby(standby)
+{
+}
+
+void MCP_CAN_25625::setStandby(bool value)
+{
+	if (value) {
+		digitalWrite(standby, HIGH);
+	} else {
+		digitalWrite(standby, LOW);
+	}
+}
+
+byte MCP_CAN_25625::sleep()
+{
+	setStandby(true);
+	return MCP_CAN::sleep();
+}
+
+byte MCP_CAN_25625::wake()
+{
+	auto ret = MCP_CAN::wake();
+	setStandby(false);
+	return ret;
+}

--- a/src/mcp_25625.cpp
+++ b/src/mcp_25625.cpp
@@ -8,11 +8,7 @@ MCP_CAN_25625::MCP_CAN_25625(pin_t cs, pin_t standby, SPIClass &spi, int speed)
 
 void MCP_CAN_25625::setStandby(bool value)
 {
-	if (value) {
-		digitalWrite(standby, HIGH);
-	} else {
-		digitalWrite(standby, LOW);
-	}
+	digitalWrite(standby, value ? HIGH : LOW);
 }
 
 byte MCP_CAN_25625::sleep()

--- a/src/mcp_25625.h
+++ b/src/mcp_25625.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "mcp_can.h"
+
+class MCP_CAN_25625 : public MCP_CAN {
+public:
+    MCP_CAN_25625(pin_t cs, pin_t standby, SPIClass &spi=SPI, int speed=10);
+
+    void setStandby(bool);
+
+    byte sleep();
+    byte wake();
+private:
+    pin_t standby;
+};

--- a/src/mcp_25625.h
+++ b/src/mcp_25625.h
@@ -4,7 +4,7 @@
 
 class MCP_CAN_25625 : public MCP_CAN {
 public:
-    MCP_CAN_25625(pin_t cs, pin_t standby, SPIClass &spi=SPI, int speed=10);
+    MCP_CAN_25625(pin_t cs, pin_t standby, SPIClass &spi=SPI, int speed=10 /* MHz */);
 
     void setStandby(bool);
 

--- a/src/mcp_can.cpp
+++ b/src/mcp_can.cpp
@@ -327,6 +327,11 @@ void MCP_CAN::setSleepWakeup(const byte enable) {
 *********************************************************************************************************/
 byte MCP_CAN::sleep() {
     if (getMode() != MCP_MODE_SLEEP) {
+        if (mcp2515_readRegister(MCP_TXB0CTRL) & MCP_TXB_TXREQ_M
+            || mcp2515_readRegister(MCP_TXB1CTRL) & MCP_TXB_TXREQ_M
+            || mcp2515_readRegister(MCP_TXB2CTRL) & MCP_TXB_TXREQ_M) {
+            mcp2515_modifyRegister(MCP_CANCTRL, MCP_ABORT_TX, MCP_ABORT_TX); // abort all TX queues
+        }
         return mcp2515_setCANCTRL_Mode(MCP_MODE_SLEEP);
     } else {
         return CAN_OK;


### PR DESCRIPTION
A subclass MCP25625 that takes the standby pin as a configuration parameter and uses it during sleep and wake. TX queues are also aborted before sleep.

With this change, modules that have the integrated transceiver can replace the driver definition using `MCP_CAN can(cs_pin)` with `MCP_CAN_25625 can(cs_pin, standby_pin)`.